### PR TITLE
Ensure pyparsing version >3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.7"
 dependencies = [
     "click",
     "fiona",
-    "pyparsing",
+    "pyparsing>=3.0",
     "shapely>=2.0",
 ]
 


### PR DESCRIPTION
My system (Ubuntu 22.04) preferred pyparsing == 2.4.7 for whatever reason. This led to the error

```
Traceback (most recent call last):
  File "/home/lobuglio/.local/lib/python3.10/site-packages/click_plugins/core.py", line 37, in decorator
    group.add_command(entry_point.load())
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/lobuglio/.local/lib/python3.10/site-packages/fio_planet/cli.py", line 38, in <module>
    from .features import map_feature, reduce_features
  File "/home/lobuglio/.local/lib/python3.10/site-packages/fio_planet/features.py", line 31, in <module>
    from . import snuggs
  File "/home/lobuglio/.local/lib/python3.10/site-packages/fio_planet/snuggs.py", line 152, in <module>
    nil = Keyword("null").set_parse_action(lambda source, loc, toks: None)
AttributeError: 'Keyword' object has no attribute 'set_parse_action'
```
fio-planet needs [pyparsing >3.0.0](https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#api-changes) to use pyparsing snake_case names 